### PR TITLE
Fixed h1 offset

### DIFF
--- a/minimal.css
+++ b/minimal.css
@@ -129,6 +129,7 @@ h1 {
   padding-top: var(--standard-padding);
   padding-left: var(--standard-padding);
   padding-right: var(--standard-padding);
+  margin: var(--standard-margin);
   text-align: center;
   color: var(--text);
   font-family: var(--sans-serif-condensed-font);


### PR DESCRIPTION
The h1 tag, which is used for page-level headings, was offset due to it having a default margin. Fixed it by adding a standard margin value used across the stylesheet.

Cause of this issue: Code refactoring for h1 a day ago.